### PR TITLE
ISL: Fix gcc 8, only builds with isl-0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-*/
-binutils
-gcc
-linux
-*.tar*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+env:
+  matrix:
+    - OS_TYPE=debian OS_VERSION=9 BUILD_TYPE=arm-linux-gnueabi
+
+script:
+  - bash docker build -f $BASEDIR/tests/dockerfile_${OS_TYPE}${OS_VERSION}.${BUILD_TYPE} .

--- a/build
+++ b/build
@@ -231,7 +231,8 @@ function parse_parameters() {
                      ISL="isl-0.17.1" ;;
             "gnu:6") GCC=gcc-6-branch ;;
             "gnu:7") GCC=gcc-7-branch ;;
-            "gnu:8") GCC=gcc-8-branch ;;
+            "gnu:8") GCC=gcc-8-branch
+                     ISL="isl-0.18" ;;
             "gnu:9") GCC=master ;;
             "linaro:4") GCC=linaro-local/releases/linaro-4.9-2017.01
                         ISL="isl-0.17.1" ;;
@@ -251,7 +252,8 @@ function parse_parameters() {
                      ISL="isl-0.17.1" ;;
             "gnu:6") GCC=gcc-6.4.0 ;;
             "gnu:7") GCC=gcc-7.3.0 ;;
-            "gnu:8") GCC=gcc-8.2.0 ;;
+            "gnu:8") GCC=gcc-8.2.0
+                     ISL="isl-0.18.0" ;;
             "gnu:9") die "GCC 9.0 is currently a WIP so there is no tarball to download! Either use the git repo or choose a new version..." ;;
             "linaro:4") GCC=linaro-4.9-2017.01
                         ISL="isl-0.17.1" ;;

--- a/build
+++ b/build
@@ -360,11 +360,6 @@ function download_sources() {
     cd ${SOURCES_DIR} || die "Failed to create sources directory!"
 
     if [[ -z ${TARBALLS} ]]; then
-        if [[ ! -d mpc-${MPC} ]]; then
-            header "DOWNLOADING MPC"
-            git_clone ${MPC_GIT_URL} mpc-${MPC} -b ${MPC}
-        fi
-
         if [[ ! -d glibc-${GLIBC} ]]; then
             header "DOWNLOADING GLIBC"
             git_clone ${GLIBC_GIT_URL} glibc-${GLIBC} -b ${GLIBC}
@@ -380,33 +375,42 @@ function download_sources() {
             git_clone ${BINUTILS_GIT_URL} binutils-${BINUTILS} -b ${BINUTILS}
         fi
 
-        if [[ ! -d isl-${ISL} ]]; then
-            header "DOWNLOADING ISL"
-            git_clone ${ISL_GIT_URL} isl-${ISL} -b ${ISL}
-        fi
-
         if [[ ! -d gcc-${GCC} ]]; then
             header "DOWNLOADING GCC"
             git_clone ${GCC_GIT_URL} gcc-${GCC} -b ${GCC}
         fi
     else
+        if [[ ! -f ${GLIBC}.tar.xz ]]; then
+            header "DOWNLOADING GLIBC"
+            axel ${GLIBC_BASE_URL}${GLIBC}.tar.xz
+        fi
+
+        if [[ ! -f linux-${LINUX}.tar.xz ]]; then
+            header "DOWNLOADING LINUX KERNEL"
+            axel ${LINUX_BASE_URL}${LINUX}.tar.xz
+        fi
+
         if [[ ! -f binutils-${BINUTILS}.tar.xz ]]; then
             header "DOWNLOADING BINUTILS"
             axel ${BINUTILS_BASE_URL}${BINUTILS}.tar.xz
         fi
 
-        if [[ ! -f ${ISL}.tar.xz ]]; then
-            header "DOWNLOADING ISL ${ISL} FOR GCC ${VERSION}"
-            axel ${ISL_BASE_URL}${ISL}.tar.xz
-        fi
-
-        if [[ ! -f gcc-${GCC}.tar.gz ]]; then
+        if [[ ! -f ${GCC}.tar.gz ]]; then
             header "DOWNLOADING GCC"
-            axel ${GCC_BASE_URL}${GCC}.tar.gz
+            axel ${GCC_BASE_URL}/${GCC}/${GCC}.tar.gz
         fi
     fi
 
-    # MPFR and GMP are not using git, so we will use the tarballs
+    if [[ ! -f ${MPC}.tar.gz ]]; then
+        header "DOWNLOADING MPC"
+        axel ${MPC_BASE_URL}${MPC}.tar.gz
+    fi
+
+    if [[ ! -f ${ISL}.tar.xz ]]; then
+        header "DOWNLOADING ISL ${ISL} FOR GCC ${VERSION}"
+        axel ${ISL_BASE_URL}${ISL}.tar.xz
+    fi
+
     if [[ ! -f ${MPFR}.tar.xz ]]; then
         header "DOWNLOADING MPFR"
         axel ${MPFR_BASE_URL}${MPFR}.tar.xz
@@ -433,13 +437,14 @@ function extract_sources() {
 
     extract ${MPFR}.tar.xz ${SOURCES_DIR}/mpfr-${MPFR}
     extract ${GMP}.tar.xz ${SOURCES_DIR}/gmp-${GMP}
+    extract ${MPC}.tar.gz ${SOURCES_DIR}/mpc-${MPC}
+    extract ${ISL}.tar.xz ${SOURCES_DIR}/isl-${ISL}
+    
     if [[ -n ${TARBALLS} ]]; then
-        extract ${MPC}.tar.gz ${SOURCES_DIR}/mpc-${MPC}
         extract ${GLIBC}.tar.xz ${SOURCES_DIR}/glibc-${GLIBC}
         extract linux-${LINUX}.tar.xz ${SOURCES_DIR}/linux-${LINUX}
         extract binutils-${BINUTILS}.tar.xz ${SOURCES_DIR}/binutils-${BINUTILS}
-        extract ${ISL}.tar.xz ${SOURCES_DIR}/isl-${ISL}
-        extract gcc-${GCC}.tar.gz ${SOURCES_DIR}/gcc-${GCC}
+        extract ${GCC}.tar.gz ${SOURCES_DIR}/gcc-${GCC}
     fi
 
     set_build_state ${FUNCNAME[0]}
@@ -563,17 +568,17 @@ function build_gcc() {
 
     header "MAKING GCC"
 
-    ln -s -f "${SOURCES_DIR}/mpfr-${MPFR}" ${SOURCES_DIR}/gcc-${GCC}/mpfr
-    ln -s -f "${SOURCES_DIR}/gmp-${GMP}" ${SOURCES_DIR}/gcc-${GCC}/gmp
-    ln -s -f "${SOURCES_DIR}/mpc-${MPC}" ${SOURCES_DIR}/gcc-${GCC}/mpc
-    ln -s -f "${SOURCES_DIR}/isl-${ISL}" ${SOURCES_DIR}/gcc-${GCC}/isl
+    ln -sfn "${SOURCES_DIR}/mpfr-${MPFR}" ${SOURCES_DIR}/gcc-${GCC}/mpfr
+    ln -sfn "${SOURCES_DIR}/gmp-${GMP}" ${SOURCES_DIR}/gcc-${GCC}/gmp
+    ln -sfn "${SOURCES_DIR}/mpc-${MPC}" ${SOURCES_DIR}/gcc-${GCC}/mpc
+    ln -sfn "${SOURCES_DIR}/isl-${ISL}" ${SOURCES_DIR}/gcc-${GCC}/isl
 
     mkdir -p ${BUILD_DIR}/build-gcc
     cd ${BUILD_DIR}/build-gcc || die "GCC build folder does not exist!"
     ${SOURCES_DIR}/gcc-${GCC}/configure "${CONFIGURATION[@]}" \
                      --enable-languages=c \
                      --target=${TARGET} \
-                     --prefix="${INSTALL}"
+                     --prefix=${INSTALL}
     make all-gcc ${JOBS} || die "Error while building gcc!" -n
     make install-gcc ${JOBS} || die "Error while installing gcc!" -n
     if [[ ${ARCH} = "x86_64" ]]; then

--- a/build
+++ b/build
@@ -29,6 +29,14 @@
 # FUNCTIONS #
 #############
 
+set -e
+
+TAR_CONFIG="${BASH_SOURCE%/*}/tar_source_config.sh"
+GIT_CONFIG="${BASH_SOURCE%/*}/git_source_config.sh"
+source ${TAR_CONFIG}
+source ${GIT_CONFIG}
+
+
 # Easy alias for escape codes
 function echo() {
     command echo -e "${@}"
@@ -158,6 +166,43 @@ function git_fetch() {
     git fetch ${DEPTH_FLAG:+"--depth=1"} "${@}"
 }
 
+function extract() {
+    case "${1}" in
+        *.gz) UNPACK=pigz ;;
+        *.xz) UNPACK=pxz ;;
+    esac
+    mkdir -p "${2}"
+    ${UNPACK} -d < "${1}" | tar -xC "${2}" --strip-components=1
+}
+
+function set_build_state() {
+    touch ${BUILD_STATE_DIR}/${1}
+}
+
+function check_build_state() {
+    if [ -e ${BUILD_STATE_DIR}/${1} ];then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function setup_environment() {
+    ROOT=${PWD}
+    PREBUILTS_BIN=${ROOT}/prebuilts/bin
+    INSTALL=${ROOT}/${TARGET}
+    SOURCES_DIR=${ROOT}/sources
+    BUILD_STATE_DIR="${ROOT}/state"
+    BUILD_DIR="${ROOT}/build_dir"
+
+    export PATH=${PREBUILTS_BIN}:${PATH}
+
+    # Maybe not needed!?
+    export PATH=${INSTALL}/bin:${PATH}
+
+    mkdir -p ${SOURCES_DIR}
+    mkdir -p ${BUILD_STATE_DIR}
+}
 
 # Initial setup
 function setup_variables() {
@@ -170,16 +215,6 @@ function setup_variables() {
     # Configuration variables
     CONFIGURATION=( "--disable-multilib" "--disable-werror" )
     JOBS="-j$(($(nproc --all) + 1))"
-
-    # Binary versions
-    BINUTILS_git="binutils-2_31-branch"
-    BINUTILS_tar="2.31"
-    GMP="gmp-6.1.2"
-    MPFR="mpfr-4.0.1"
-    MPC="mpc-1.1.0"
-    ISL="isl-0.20"
-    GLIBC="glibc-2.28"
-    LINUX="4.18"
 
     # Start of script
     START=$(date +%s)
@@ -227,19 +262,15 @@ function parse_parameters() {
         # Set GCC branch based on version and Linaro or not
         case "${SOURCE}:${VERSION}" in
             "gnu:4") die "Will not build, Use Linaro instead" ;;
-            "gnu:5") GCC=gcc-5-branch
-                     ISL="isl-0.17.1" ;;
-            "gnu:6") GCC=gcc-6-branch ;;
-            "gnu:7") GCC=gcc-7-branch ;;
-            "gnu:8") GCC=gcc-8-branch
-                     ISL="isl-0.18" ;;
-            "gnu:9") GCC=master ;;
-            "linaro:4") GCC=linaro-local/releases/linaro-4.9-2017.01
-                        ISL="isl-0.17.1" ;;
-            "linaro:5") GCC=linaro-local/gcc-5-integration-branch
-                        ISL="isl-0.17.1" ;;
-            "linaro:6") GCC=linaro-local/gcc-6-integration-branch ;;
-            "linaro:7") GCC=linaro-local/gcc-7-integration-branch ;;
+            "gnu:5") setup_variables_git_gnu_5 ;;
+            "gnu:6") setup_variables_git_gnu_6 ;;
+            "gnu:7") setup_variables_git_gnu_7 ;;
+            "gnu:8") setup_variables_git_gnu_8 ;;
+            "gnu:9") setup_variables_git_gnu_9 ;;
+            "linaro:4") setup_variables_git_linaro_4 ;;
+            "linaro:5") setup_variables_git_linaro_5 ;;
+            "linaro:6") setup_variables_git_linaro_6 ;;
+            "linaro:7") setup_variables_git_linaro_7 ;;
             "linaro:8") die "There's no such thing as Linaro 8.x Clannad..." -h ;;
             "linaro:9") die "There's no such thing as Linaro 9.x Clannad..." -h ;;
             *) die "Absent or invalid GCC version or source specified!" -h ;;
@@ -248,19 +279,15 @@ function parse_parameters() {
         # Set GCC branch based on version and Linaro or not
         case "${SOURCE}:${VERSION}" in
             "gnu:4") die "Will not build, Use Linaro instead" ;;
-            "gnu:5") GCC=gcc-5.5.0
-                     ISL="isl-0.17.1" ;;
-            "gnu:6") GCC=gcc-6.4.0 ;;
-            "gnu:7") GCC=gcc-7.3.0 ;;
-            "gnu:8") GCC=gcc-8.2.0
-                     ISL="isl-0.18.0" ;;
+            "gnu:5") setup_variables_tar_gnu_5 ;;
+            "gnu:6") setup_variables_tar_gnu_6 ;;
+            "gnu:7") setup_variables_tar_gnu_7 ;;
+            "gnu:8") setup_variables_tar_gnu_8 ;;
             "gnu:9") die "GCC 9.0 is currently a WIP so there is no tarball to download! Either use the git repo or choose a new version..." ;;
-            "linaro:4") GCC=linaro-4.9-2017.01
-                        ISL="isl-0.17.1" ;;
-            "linaro:5") GCC=linaro-5.5-2017.10
-                        ISL="isl-0.17.1" ;;
-            "linaro:6") GCC=linaro-snapshot-6.4-2018.06 ;;
-            "linaro:7") GCC=linaro-snapshot-7.3-2018.06 ;;
+            "linaro:4") setup_variables_tar_linaro_4 ;;
+            "linaro:5") setup_variables_tar_linaro_5 ;;
+            "linaro:6") setup_variables_tar_linaro_6 ;;
+            "linaro:7") setup_variables_tar_linaro_7 ;;
             "linaro:8") die "There's no such thing as Linaro 8.x Clannad..." -h ;;
             "linaro:9") die "There's no such thing as Linaro 9.x Clannad..." -h ;;
             *) die "Absent or invalid GCC version or source specified!" -h ;;
@@ -274,7 +301,7 @@ function clean_up() { #FIXME: we dont need to remove everything everytime.
     header "CLEANING UP"
 
     unmount_tmpfs
-    git clean -fxdq -e sources -e prebuilts
+    git clean -fxdq -e sources -e prebuilts || true
     find . -maxdepth 1 -type l -exec rm -rf {} \; #FIXME
     if [[ -d binutils ]] ||
        [[ -d build-binutils ]] ||
@@ -293,141 +320,129 @@ function clean_up() { #FIXME: we dont need to remove everything everytime.
 
 
 function build_binaries() {
-    ROOT=${PWD}
-    PREBUILTS_BIN=${ROOT}/prebuilts/bin
-    mkdir -p sources
 
-    if [[ ! -f ${PREBUILTS_BIN}/axel ]]; then
-        AXEL=${ROOT}/sources/axel
-        [[ ! -d ${AXEL} ]] && git -C "$(dirname "${AXEL}")" clone --depth=1 https://github.com/axel-download-accelerator/axel
-        git -C "${AXEL}" clean -fxdq
-        git -C "${AXEL}" pull
-        (
-            cd "${AXEL}" || die "Issue with cloning axel source!"
-            ./autogen.sh
-            ./configure --prefix="$(dirname "${PREBUILTS_BIN}")"
-            make ${JOBS} || die "Error building axel!"
-            make ${JOBS} install || die "Error installing axel!"
-        )
-    fi
+    check_build_state ${FUNCNAME[0]} && return
 
-    if [[ ! -f ${PREBUILTS_BIN}/pigz ]]; then
-        PIGZ=${ROOT}/sources/pigz
-        [[ ! -d ${PIGZ} ]] && git -C "$(dirname "${PIGZ}")" clone --depth=1 https://github.com/madler/pigz
-        git -C "${PIGZ}" clean -fxdq
-        git -C "${PIGZ}" pull
-        make -C "${PIGZ}" ${JOBS} pigz || die "Error building pigz!"
-        mv "${PIGZ}"/pigz "${PREBUILTS_BIN}"
-    fi
+    local AXEL=${ROOT}/sources/axel
+    [[ ! -d ${AXEL} ]] && git -C "$(dirname "${AXEL}")" clone --depth=1 https://github.com/axel-download-accelerator/axel
+    git -C "${AXEL}" clean -fxdq
+    git -C "${AXEL}" pull
+    (
+        cd "${AXEL}" || die "Issue with cloning axel source!"
+        ./autogen.sh
+        ./configure --prefix="$(dirname "${PREBUILTS_BIN}")"
+        make ${JOBS} || die "Error building axel!"
+        make ${JOBS} install || die "Error installing axel!"
+    )
 
-    if [[ ! -f ${PREBUILTS_BIN}/pxz ]]; then
-        PXZ=${ROOT}/sources/pxz
-        [[ ! -d ${PXZ} ]] && git -C "$(dirname "${PXZ}")" clone --depth=1 https://github.com/jnovy/pxz
-        git -C "${PXZ}" clean -fxdq
-        git -C "${PXZ}" pull
-        make -C "${PXZ}" ${JOBS} pxz || die "Error building pxz!"
-        mv "${PXZ}"/pxz "${PREBUILTS_BIN}"
-    fi
+    local PIGZ=${ROOT}/sources/pigz
+    [[ ! -d ${PIGZ} ]] && git -C "$(dirname "${PIGZ}")" clone --depth=1 https://github.com/madler/pigz
+    git -C "${PIGZ}" clean -fxdq
+    git -C "${PIGZ}" pull
+    make -C "${PIGZ}" ${JOBS} pigz || die "Error building pigz!"
+    mv "${PIGZ}"/pigz "${PREBUILTS_BIN}"
 
-    export PATH=${PREBUILTS_BIN}:${PATH}
+    local PXZ=${ROOT}/sources/pxz
+    [[ ! -d ${PXZ} ]] && git -C "$(dirname "${PXZ}")" clone --depth=1 https://github.com/jnovy/pxz
+    git -C "${PXZ}" clean -fxdq
+    git -C "${PXZ}" pull
+    make -C "${PXZ}" ${JOBS} pxz || die "Error building pxz!"
+    mv "${PXZ}"/pxz "${PREBUILTS_BIN}"
+
+    set_build_state ${FUNCNAME[0]}
 }
 
 
 function download_sources() {
-    cd sources || die "Failed to create sources directory!"
 
-    if [[ ! -f ${MPFR}.tar.xz ]]; then
-        header "DOWNLOADING MPR"
-        axel https://www.mpfr.org/mpfr-current/${MPFR}.tar.xz
-    fi
+    check_build_state ${FUNCNAME[0]} && return
 
-    if [[ ! -f ${GMP}.tar.xz ]]; then
-        header "DOWNLOADING GMP"
-        axel https://ftp.gnu.org/gnu/gmp/${GMP}.tar.xz
-    fi
-
-    if [[ ! -f ${MPC}.tar.gz ]]; then
-        header "DOWNLOADING MPC"
-        axel https://ftp.gnu.org/gnu/mpc/${MPC}.tar.gz
-    fi
-
-    if [[ ! -f ${GLIBC}.tar.xz ]]; then
-        header "DOWNLOADING GLIBC"
-        axel https://ftp.gnu.org/gnu/glibc/${GLIBC}.tar.xz
-    fi
-
-    if [[ ! -f linux-${LINUX}.tar.xz ]]; then
-        header "DOWNLOADING LINUX KERNEL"
-        axel https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${LINUX}.tar.xz
-    fi
+    cd ${SOURCES_DIR} || die "Failed to create sources directory!"
 
     if [[ -z ${TARBALLS} ]]; then
-        if [[ ! -d binutils ]]; then
+        if [[ ! -d mpc-${MPC} ]]; then
+            header "DOWNLOADING MPC"
+            git_clone ${MPC_GIT_URL} mpc-${MPC} -b ${MPC}
+        fi
+
+        if [[ ! -d glibc-${GLIBC} ]]; then
+            header "DOWNLOADING GLIBC"
+            git_clone ${GLIBC_GIT_URL} glibc-${GLIBC} -b ${GLIBC}
+        fi
+
+        if [[ ! -d linux-${LINUX} ]]; then
+            header "DOWNLOADING LINUX KERNEL"
+            git_clone ${LINUX_GIT_URL} linux-${LINUX} -b ${LINUX}
+        fi
+
+        if [[ ! -d binutils-${BINUTILS} ]]; then
             header "DOWNLOADING BINUTILS"
-            git_clone https://git.linaro.org/toolchain/binutils-gdb.git binutils -b ${BINUTILS_git}
+            git_clone ${BINUTILS_GIT_URL} binutils-${BINUTILS} -b ${BINUTILS}
         fi
 
-        if [[ ! -d isl ]]; then
+        if [[ ! -d isl-${ISL} ]]; then
             header "DOWNLOADING ISL"
-            git_clone git://repo.or.cz/isl.git -b ${ISL}
+            git_clone ${ISL_GIT_URL} isl-${ISL} -b ${ISL}
         fi
 
-        if [[ ! -d gcc ]]; then
+        if [[ ! -d gcc-${GCC} ]]; then
             header "DOWNLOADING GCC"
-            git_clone https://git.linaro.org/toolchain/gcc.git -b ${GCC}
+            git_clone ${GCC_GIT_URL} gcc-${GCC} -b ${GCC}
         fi
     else
-        if [[ ! -f binutils-${BINUTILS_tar}.tar.xz ]]; then
+        if [[ ! -f binutils-${BINUTILS}.tar.xz ]]; then
             header "DOWNLOADING BINUTILS"
-            axel https://ftp.gnu.org/gnu/binutils/binutils-${BINUTILS_tar}.tar.xz
+            axel ${BINUTILS_BASE_URL}${BINUTILS}.tar.xz
         fi
 
         if [[ ! -f ${ISL}.tar.xz ]]; then
             header "DOWNLOADING ISL ${ISL} FOR GCC ${VERSION}"
-            axel http://isl.gforge.inria.fr/${ISL}.tar.xz
+            axel ${ISL_BASE_URL}${ISL}.tar.xz
         fi
 
-        if [[ ${SOURCE} == "gnu" ]]; then
-            if [[ ! -f ${GCC}.tar.${EXT:-xz} ]]; then
-                header "DOWNLOADING GCC"
-                axel https://mirrors.kernel.org/gnu/gcc/${GCC}/${GCC}.tar."${EXT:-gz}"
-            fi
-            GCC_TAR=${GCC}.tar.${EXT:-gz}
-        else
-            if [[ ! -f gcc-${GCC}.tar.gz ]]; then
-                header "DOWNLOADING GCC"
-                axel https://git.linaro.org/toolchain/gcc.git/snapshot/gcc-${GCC}.tar.gz
-            fi
-            GCC_TAR=gcc-${GCC}.tar.gz
+        if [[ ! -f gcc-${GCC}.tar.gz ]]; then
+            header "DOWNLOADING GCC"
+            axel ${GCC_BASE_URL}${GCC}.tar.gz
         fi
     fi
 
+    # MPFR and GMP are not using git, so we will use the tarballs
+    if [[ ! -f ${MPFR}.tar.xz ]]; then
+        header "DOWNLOADING MPFR"
+        axel ${MPFR_BASE_URL}${MPFR}.tar.xz
+    fi
+
+    if [[ ! -f ${GMP}.tar.xz ]]; then
+        header "DOWNLOADING GMP"
+        axel ${GMP_BASE_URL}${GMP}.tar.xz
+    fi
+
+    cd ${ROOT}
+
+    set_build_state ${FUNCNAME[0]}
 }
-
-
-function extract() {
-    case "${1}" in
-        *.gz) UNPACK=pigz ;;
-        *.xz) UNPACK=pxz ;;
-    esac
-    mkdir -p "${2}"
-    ${UNPACK} -d < "${1}" | tar -xC "${2}" --strip-components=1
-}
-
 
 # Extract tarballs to their proper locations
 function extract_sources() {
+
+    check_build_state ${FUNCNAME[0]} && return
+
     header "EXTRACTING DOWNLOADED TARBALLS"
-    extract ${MPFR}.tar.xz ../${MPFR}
-    extract ${GMP}.tar.xz ../${GMP}
-    extract ${MPC}.tar.gz ../${MPC}
-    extract ${GLIBC}.tar.xz ../${GLIBC}
-    extract linux-${LINUX}.tar.xz ../linux
+
+    cd ${SOURCES_DIR}
+
+    extract ${MPFR}.tar.xz ${SOURCES_DIR}/mpfr-${MPFR}
+    extract ${GMP}.tar.xz ${SOURCES_DIR}/gmp-${GMP}
     if [[ -n ${TARBALLS} ]]; then
-        extract binutils-${BINUTILS_tar}.tar.xz ../binutils
-        extract ${ISL}.tar.xz ../${ISL}
-        extract ${GCC_TAR} ../gcc
+        extract ${MPC}.tar.gz ${SOURCES_DIR}/mpc-${MPC}
+        extract ${GLIBC}.tar.xz ${SOURCES_DIR}/glibc-${GLIBC}
+        extract linux-${LINUX}.tar.xz ${SOURCES_DIR}/linux-${LINUX}
+        extract binutils-${BINUTILS}.tar.xz ${SOURCES_DIR}/binutils-${BINUTILS}
+        extract ${ISL}.tar.xz ${SOURCES_DIR}/isl-${ISL}
+        extract gcc-${GCC}.tar.gz ${SOURCES_DIR}/gcc-${GCC}
     fi
+
+    set_build_state ${FUNCNAME[0]}
 }
 
 
@@ -444,9 +459,9 @@ function update_repos() {
         )
         (
             cd binutils || die "binutils did not get cloned properly!"
-            [[ -n ${FULL_SOURCE} ]] && BRANCH=origin/${BINUTILS_git} || BRANCH=FETCH_HEAD
-            git_fetch origin ${BINUTILS_git}
-            git checkout ${BINUTILS_git} || git checkout -b ${BINUTILS_git} ${BRANCH}
+            [[ -n ${FULL_SOURCE} ]] && BRANCH=origin/${BINUTILS} || BRANCH=FETCH_HEAD
+            git_fetch origin ${BINUTILS}
+            git checkout ${BINUTILS} || git checkout -b ${BINUTILS} ${BRANCH}
             git reset --hard ${BRANCH}
         )
         (
@@ -475,8 +490,6 @@ function update_repos() {
 
 # Setup source folders and build folders
 function setup_env() {
-    INSTALL=${ROOT}/${TARGET}
-    export PATH=${INSTALL}/bin:${PATH}
 
     [[ ! -d gcc ]] && die "GCC source is missing! Please check your connection and rerun the script!" -h
 
@@ -511,32 +524,53 @@ function setup_env() {
 
 # Build binutils
 function build_binutils() {
+
+    check_build_state ${FUNCNAME[0]} && return
+
     header "BUILDING BINUTILS"
-    cd build-binutils || die "binutils build folder does not exist!"
-    ../binutils/configure "${CONFIGURATION[@]}" \
+    mkdir -p ${BUILD_DIR}/build-binutils
+    cd ${BUILD_DIR}/build-binutils
+    ${SOURCES_DIR}/binutils-${BINUTILS}/configure "${CONFIGURATION[@]}" \
                           --target=${TARGET} \
                           --prefix="${INSTALL}" \
                           --disable-gdb
     make ${JOBS} || die "Error while building binutils!" -n
     make install ${JOBS} || die "Error while installing binutils!" -n
+
+    set_build_state ${FUNCNAME[0]}
 }
 
 
 # Make Linux kernel headers
 function build_headers() {
+
+    check_build_state ${FUNCNAME[0]} && return
+
     header "MAKING LINUX HEADERS"
-    cd ../linux || die "Linux kernel folder does not exist!"
+    cd ${SOURCES_DIR}/linux-${LINUX} || die "Linux kernel folder does not exist!"
     make ARCH="${ARCH}" \
         INSTALL_HDR_PATH="${INSTALL}/${TARGET}" \
         headers_install ${JOBS} || die "Error while building/installing Linux headers!" -n
+
+    set_build_state ${FUNCNAME[0]}
 }
 
 
 # Build GCC
 function build_gcc() {
+
+    check_build_state ${FUNCNAME[0]} && return
+
     header "MAKING GCC"
-    cd ../build-gcc || die "GCC build folder does not exist!"
-    ../gcc/configure "${CONFIGURATION[@]}" \
+
+    ln -s -f "${SOURCES_DIR}/mpfr-${MPFR}" ${SOURCES_DIR}/gcc-${GCC}/mpfr
+    ln -s -f "${SOURCES_DIR}/gmp-${GMP}" ${SOURCES_DIR}/gcc-${GCC}/gmp
+    ln -s -f "${SOURCES_DIR}/mpc-${MPC}" ${SOURCES_DIR}/gcc-${GCC}/mpc
+    ln -s -f "${SOURCES_DIR}/isl-${ISL}" ${SOURCES_DIR}/gcc-${GCC}/isl
+
+    mkdir -p ${BUILD_DIR}/build-gcc
+    cd ${BUILD_DIR}/build-gcc || die "GCC build folder does not exist!"
+    ${SOURCES_DIR}/gcc-${GCC}/configure "${CONFIGURATION[@]}" \
                      --enable-languages=c \
                      --target=${TARGET} \
                      --prefix="${INSTALL}"
@@ -546,14 +580,20 @@ function build_gcc() {
         make all-target-libgcc ${JOBS} || die "Error while installing libgcc for host!" -n
         make install-target-libgcc ${JOBS} || die "Error while installing libgcc for target!" -n
     fi
+
+    set_build_state ${FUNCNAME[0]}
 }
 
 
 # Build glibc
 function build_glibc() {
+
+    check_build_state ${FUNCNAME[0]} && return
+
     header "MAKING GLIBC"
-    cd ../build-glibc || die "glibc build folder does not exist!"
-    ../${GLIBC}/configure --prefix="${INSTALL}/${TARGET}" \
+    mkdir -p ${BUILD_DIR}/build-glibc
+    cd ${BUILD_DIR}/build-glibc || die "glibc build folder does not exist!"
+    ${SOURCES_DIR}/glibc-${GLIBC}/configure --prefix="${INSTALL}/${TARGET}" \
                           --build="${MACHTYPE}" \
                           --host=${TARGET} \
                           --target=${TARGET} \
@@ -568,29 +608,39 @@ function build_glibc() {
         make ${JOBS} || die "Error while building glibc for the host!" -n
         make install ${JOBS} || die "Error while installing glibc for the host!" -n
     else
-        cd ../build-gcc || die "GCC build folder does not exist!"
+        cd ${BUILD_DIR}/build-gcc || die "GCC build folder does not exist!"
         make all-target-libgcc ${JOBS} || die "Error while building libgcc for target!" -n
         make install-target-libgcc ${JOBS} || die "Error while installing libgcc for target!" -n
 
-        cd ../build-glibc || die "glibc build folder does not exist!"
+        cd ${BUILD_DIR}/build-glibc || die "glibc build folder does not exist!"
         make ${JOBS} || die "Error while building glibc for target" -n
         make install ${JOBS} || die "Error while installing glibc for target" -n
     fi
+
+    set_build_state ${FUNCNAME[0]}
 }
 
 
 # Install GCC
 function install_gcc() {
+
+    check_build_state ${FUNCNAME[0]} && return
+
     header "INSTALLING GCC"
     cd ../build-gcc || die "GCC build folder does not exist!"
     make all ${JOBS} || die "Error while compiling final toolchain!" -n
     make install ${JOBS} || die "Error while installing final toolchain!" -n
     cd ..
+
+    set_build_state ${FUNCNAME[0]}
 }
 
 
 # Package toolchain
 function package_tc() {
+
+    check_build_state ${FUNCNAME[0]} && return
+
     if [[ -n ${COMPRESSION} ]]; then
         PACKAGE=${TARGET}-${VERSION}.x-${SOURCE}-$(TZ=UTC date +%Y%m%d).tar.${COMPRESSION}
 
@@ -609,11 +659,16 @@ function package_tc() {
                 die "Invalid compression specified... skipping" ;;
         esac
     fi
+
+    set_build_state ${FUNCNAME[0]}    
 }
 
 
 # Ending information
 function ending_info() {
+
+    check_build_state ${FUNCNAME[0]} && return
+
     END=$(date +%s)
 
     [[ -z ${VERBOSE} ]] && exec 1>&5 2>&6
@@ -633,23 +688,25 @@ function ending_info() {
 
     # Alert to script end
     echo "\a"
+
+    set_build_state ${FUNCNAME[0]}    
 }
 
-
-setup_variables
 parse_parameters "${@}"
+setup_variables
+setup_environment
 trap 'unmount_tmpfs; die "Manually aborted!" -n' SIGINT SIGTERM
 trap 'unmount_tmpfs' EXIT
-clean_up
+#clean_up
 build_binaries
 download_sources
 extract_sources
-update_repos
-setup_env
+#update_repos
+#setup_env
 build_binutils
 build_headers
 build_gcc
-build_glibc
-install_gcc
-package_tc
-ending_info
+#build_glibc
+#install_gcc
+#package_tc
+#ending_info

--- a/build
+++ b/build
@@ -607,10 +607,9 @@ function install_gcc() {
     check_build_state ${FUNCNAME[0]} && return
 
     header "INSTALLING GCC"
-    cd ../build-gcc || die "GCC build folder does not exist!"
+    cd ${BUILD_DIR}/build-gcc || die "GCC build folder does not exist!"
     make all ${JOBS} || die "Error while compiling final toolchain!" -n
     make install ${JOBS} || die "Error while installing final toolchain!" -n
-    cd ..
 
     set_build_state ${FUNCNAME[0]}
 }
@@ -684,7 +683,7 @@ extract_sources
 build_binutils
 build_headers
 build_gcc
-#build_glibc
-#install_gcc
-#package_tc
-#ending_info
+build_glibc
+install_gcc
+package_tc
+ending_info

--- a/build
+++ b/build
@@ -59,7 +59,6 @@ function help_menu() {
     echo
     echo "${BOLD}OPTIONAL PARAMETERS:${RST}"
     echo "  -f  | --full-src:    Download full git repos instead of shallow clones"
-    echo "  -nt | --no-tmpfs:    Do not use tmpfs for building (useful if you don't have much RAM)."
     echo "  -nu | --no-update:   Do not update the downloaded components before building (useful if you have slow internet)."
     echo "  -p  | --package:     Possible values: gz or xz. Compresses toolchain after build."
     echo "  -t  | --tarballs:    Use tarballs for binutils, ISL, and, GCC"
@@ -132,28 +131,6 @@ function format_time() {
 
     echo "${TIME_STRING}"
 }
-
-
-# Check if user needs to enter sudo password or not
-function check_sudo() {
-    echo
-    echo "Checking if sudo is available, please enter your password if a prompt appears!"
-    if ! sudo -v 2>/dev/null; then
-        warn "Sudo is not available! Disabling the option for tmpfs..." -n
-        NO_TMPFS=true
-    fi
-}
-
-
-# Unmount tmpfs
-function unmount_tmpfs() {
-    if [[ -z ${NO_TMPFS} ]]; then
-        sudo umount -f build-glibc 2>/dev/null
-        sudo umount -f build-gcc 2>/dev/null
-        sudo umount -f build-binutils 2>/dev/null
-    fi
-}
-
 
 # git clone wrapper
 function git_clone() {
@@ -232,7 +209,6 @@ function parse_parameters() {
 
             # OPTIONAL FLAGS
             "-f"|"--full-src") FULL_SOURCE=true ;;
-            "-nt"|"--no-tmpfs") NO_TMPFS=true ;;
             "-nu"|"--no-update") NO_UPDATE=true ;;
             "-p"|"--package") shift && COMPRESSION=${1} ;;
             "-t"|"--tarballs") TARBALLS=true ;;
@@ -245,7 +221,6 @@ function parse_parameters() {
         shift
     done
 
-    [[ -z ${NO_TMPFS} ]] && check_sudo
     [[ -z ${VERBOSE} ]] && exec 6>&2 5>&1 &>/dev/null
     [[ -z ${FULL_SOURCE} ]] && DEPTH_FLAG=true
 
@@ -439,7 +414,7 @@ function extract_sources() {
     extract ${GMP}.tar.xz ${SOURCES_DIR}/gmp-${GMP}
     extract ${MPC}.tar.gz ${SOURCES_DIR}/mpc-${MPC}
     extract ${ISL}.tar.xz ${SOURCES_DIR}/isl-${ISL}
-    
+
     if [[ -n ${TARBALLS} ]]; then
         extract ${GLIBC}.tar.xz ${SOURCES_DIR}/glibc-${GLIBC}
         extract linux-${LINUX}.tar.xz ${SOURCES_DIR}/linux-${LINUX}
@@ -700,8 +675,6 @@ function ending_info() {
 parse_parameters "${@}"
 setup_variables
 setup_environment
-trap 'unmount_tmpfs; die "Manually aborted!" -n' SIGINT SIGTERM
-trap 'unmount_tmpfs' EXIT
 #clean_up
 build_binaries
 download_sources

--- a/build
+++ b/build
@@ -71,7 +71,7 @@ function help_menu() {
 function header() {
     [[ "${*}" =~ "--no-first-echo" ]] || echo
     # shellcheck disable=SC2034
-    echo "${RED}====$(for i in $(seq ${#1}); do echo "=\c"; done)===="
+    echo "${GRN}====$(for i in $(seq ${#1}); do echo "=\c"; done)===="
     echo "==  ${1}  =="
     # shellcheck disable=SC2034
     echo "====$(for i in $(seq ${#1}); do echo "=\c"; done)====${RST}"
@@ -188,6 +188,7 @@ function setup_variables() {
     RED="\033[01;31m"
     RST="\033[0m"
     YLW="\033[01;33m"
+    GRN="\033[1;32m"
 
     # Configuration variables
     CONFIGURATION=( "--disable-multilib" "--disable-werror" )
@@ -271,32 +272,10 @@ function parse_parameters() {
 }
 
 
-# Clean up from a previous compilation
-function clean_up() { #FIXME: we dont need to remove everything everytime.
-    header "CLEANING UP"
-
-    unmount_tmpfs
-    git clean -fxdq -e sources -e prebuilts || true
-    find . -maxdepth 1 -type l -exec rm -rf {} \; #FIXME
-    if [[ -d binutils ]] ||
-       [[ -d build-binutils ]] ||
-       [[ -d build-gcc ]] ||
-       [[ -d build-glibc ]] ||
-       [[ -d gcc ]] ||
-       [[ -d linux ]] ||
-       [[ -f ${TARGET} ]] ||
-       [[ $(for FILE in *.tar.*; do if [[ -f "${FILE}" ]]; then echo "true"; break; else echo "false"; fi done) = "true" ]]; then
-
-        die "Clean up failed! Aborting. Try checking that you have proper permissions to delete files."
-    else
-        echo "Clean up successful!"
-    fi
-}
-
-
 function build_binaries() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}    
 
     local AXEL=${ROOT}/sources/axel
     [[ ! -d ${AXEL} ]] && git -C "$(dirname "${AXEL}")" clone --depth=1 https://github.com/axel-download-accelerator/axel
@@ -331,6 +310,7 @@ function build_binaries() {
 function download_sources() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}    
 
     cd ${SOURCES_DIR} || die "Failed to create sources directory!"
 
@@ -405,6 +385,7 @@ function download_sources() {
 function extract_sources() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}    
 
     header "EXTRACTING DOWNLOADED TARBALLS"
 
@@ -426,86 +407,11 @@ function extract_sources() {
 }
 
 
-# Update git repos
-function update_repos() {
-    if [[ -z ${NO_UPDATE} && -z ${TARBALLS} ]]; then
-        header "UPDATING SOURCES"
-        (
-            cd isl || die "ISL did not get cloned properly!"
-            git remote update
-            git checkout ${ISL}
-            git reset --hard HEAD
-            ./autogen.sh
-        )
-        (
-            cd binutils || die "binutils did not get cloned properly!"
-            [[ -n ${FULL_SOURCE} ]] && BRANCH=origin/${BINUTILS} || BRANCH=FETCH_HEAD
-            git_fetch origin ${BINUTILS}
-            git checkout ${BINUTILS} || git checkout -b ${BINUTILS} ${BRANCH}
-            git reset --hard ${BRANCH}
-        )
-        (
-            cd gcc || die "GCC did not get cloned properly!"
-            [[ -n ${FULL_SOURCE} ]] && BRANCH=origin/${GCC} || BRANCH=FETCH_HEAD
-            git_fetch origin ${GCC}
-            git checkout ${GCC} || git checkout -b ${GCC} ${BRANCH}
-            git reset --hard ${BRANCH}
-        )
-    else
-        if [[ -d isl ]]; then
-            (
-                cd isl || die "ISL did not get downloaded properly!"
-                ./autogen.sh
-            )
-        fi
-    fi
-
-    cd ..
-
-    [[ ! -d linux ]] && ln -s sources/linux linux
-    [[ ! -d binutils ]] && ln -s sources/binutils binutils
-    [[ ! -d gcc ]] && ln -s sources/gcc gcc
-}
-
-
-# Setup source folders and build folders
-function setup_env() {
-
-    [[ ! -d gcc ]] && die "GCC source is missing! Please check your connection and rerun the script!" -h
-
-    mkdir build-glibc
-    mkdir build-gcc
-    mkdir build-binutils
-
-    if [[ -z ${NO_TMPFS} ]]; then
-        sudo mount -t tmpfs -o rw none build-glibc
-        sudo mount -t tmpfs -o rw none build-gcc
-        sudo mount -t tmpfs -o rw none build-binutils
-    fi
-
-    cd gcc || die "GCC folder does not exit!"
-    ln -s -f "${ROOT}/${MPFR}" mpfr
-    ln -s -f "${ROOT}/${GMP}" gmp
-    ln -s -f "${ROOT}/${MPC}" mpc
-    if [[ -n ${TARBALLS} ]]; then
-        ln -s -f "${ROOT}/${ISL}" isl
-    else
-        ln -s -f "${ROOT}/isl" isl
-    fi
-    cd ..
-
-    if [[ -z ${VERBOSE} ]]; then
-        exec 1>&5 2>&6
-        header "BUILDING TOOLCHAIN"
-        exec 6>&2 5>&1 &>/dev/null
-    fi
-}
-
-
 # Build binutils
 function build_binutils() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}    
 
     header "BUILDING BINUTILS"
     mkdir -p ${BUILD_DIR}/build-binutils
@@ -525,6 +431,7 @@ function build_binutils() {
 function build_headers() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}
 
     header "MAKING LINUX HEADERS"
     cd ${SOURCES_DIR}/linux-${LINUX} || die "Linux kernel folder does not exist!"
@@ -540,6 +447,7 @@ function build_headers() {
 function build_gcc() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}
 
     header "MAKING GCC"
 
@@ -556,11 +464,7 @@ function build_gcc() {
                      --prefix=${INSTALL}
     make all-gcc ${JOBS} || die "Error while building gcc!" -n
     make install-gcc ${JOBS} || die "Error while installing gcc!" -n
-    if [[ ${ARCH} = "x86_64" ]]; then
-        make all-target-libgcc ${JOBS} || die "Error while installing libgcc for host!" -n
-        make install-target-libgcc ${JOBS} || die "Error while installing libgcc for target!" -n
-    fi
-
+ 
     set_build_state ${FUNCNAME[0]}
 }
 
@@ -569,6 +473,7 @@ function build_gcc() {
 function build_glibc() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}
 
     header "MAKING GLIBC"
     mkdir -p ${BUILD_DIR}/build-glibc
@@ -584,18 +489,14 @@ function build_glibc() {
     install csu/crt1.o csu/crti.o csu/crtn.o "${INSTALL}/${TARGET}/lib"
     ${TARGET}-gcc -nostdlib -nostartfiles -shared -x c /dev/null -o "${INSTALL}/${TARGET}/lib/libc.so"
     touch "${INSTALL}/${TARGET}/include/gnu/stubs.h"
-    if [[ ${ARCH} = "x86_64" || ${ARCH} = "i686" ]]; then
-        make ${JOBS} || die "Error while building glibc for the host!" -n
-        make install ${JOBS} || die "Error while installing glibc for the host!" -n
-    else
-        cd ${BUILD_DIR}/build-gcc || die "GCC build folder does not exist!"
-        make all-target-libgcc ${JOBS} || die "Error while building libgcc for target!" -n
-        make install-target-libgcc ${JOBS} || die "Error while installing libgcc for target!" -n
 
-        cd ${BUILD_DIR}/build-glibc || die "glibc build folder does not exist!"
-        make ${JOBS} || die "Error while building glibc for target" -n
-        make install ${JOBS} || die "Error while installing glibc for target" -n
-    fi
+    cd ${BUILD_DIR}/build-gcc || die "GCC build folder does not exist!"
+    make all-target-libgcc ${JOBS} || die "Error while building libgcc for target!" -n
+    make install-target-libgcc ${JOBS} || die "Error while installing libgcc for target!" -n
+
+    cd ${BUILD_DIR}/build-glibc || die "glibc build folder does not exist!"
+    make ${JOBS} || die "Error while building glibc for target" -n
+    make install ${JOBS} || die "Error while installing glibc for target" -n
 
     set_build_state ${FUNCNAME[0]}
 }
@@ -605,6 +506,7 @@ function build_glibc() {
 function install_gcc() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}    
 
     header "INSTALLING GCC"
     cd ${BUILD_DIR}/build-gcc || die "GCC build folder does not exist!"
@@ -619,6 +521,7 @@ function install_gcc() {
 function package_tc() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}    
 
     if [[ -n ${COMPRESSION} ]]; then
         PACKAGE=${TARGET}-${VERSION}.x-${SOURCE}-$(TZ=UTC date +%Y%m%d).tar.${COMPRESSION}
@@ -647,8 +550,12 @@ function package_tc() {
 function ending_info() {
 
     check_build_state ${FUNCNAME[0]} && return
+    cd ${ROOT}    
 
     END=$(date +%s)
+
+    echo "`pwd`"
+    echo "${TARGET}/bin/${TARGET}-gcc"
 
     [[ -z ${VERBOSE} ]] && exec 1>&5 2>&6
     if [[ -e ${TARGET}/bin/${TARGET}-gcc ]]; then
@@ -668,18 +575,15 @@ function ending_info() {
     # Alert to script end
     echo "\a"
 
-    set_build_state ${FUNCNAME[0]}    
+    set_build_state ${FUNCNAME[0]}
 }
 
 parse_parameters "${@}"
 setup_variables
 setup_environment
-#clean_up
 build_binaries
 download_sources
 extract_sources
-#update_repos
-#setup_env
 build_binutils
 build_headers
 build_gcc

--- a/git_source_config.sh
+++ b/git_source_config.sh
@@ -1,0 +1,138 @@
+function setup_common_urls_git() {
+    MPFR_BASE_URL="https://www.mpfr.org/mpfr-current/"
+    GMP_BASE_URL="https://ftp.gnu.org/gnu/gmp/"
+    BINUTILS_GIT_URL="https://git.linaro.org/toolchain/binutils-gdb.git"
+    ISL_GIT_URL="git://repo.or.cz/isl.git"
+    MPC_GIT_URL="https://scm.gforge.inria.fr/anonscm/git/mpc/mpc.git"
+    GLIBC_GIT_URL="git://sourceware.org/git/glibc.git"
+    LINUX_GIT_URL="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
+}
+
+function setup_base_urls_git_gnu() {
+    GCC_GIT_URL="git://gcc.gnu.org/git/gcc.git"
+
+    setup_common_urls_git
+}
+
+function setup_base_urls_git_linaro() {
+    GCC_GIT_URL="https://git.linaro.org/toolchain/gcc.git"
+
+    setup_common_urls_git
+}
+
+function setup_variables_git_gnu_9() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.18"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="master"
+
+    setup_base_urls_git_gnu
+}
+
+function setup_variables_git_gnu_8() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.18"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="gcc-8-branch"
+
+    setup_base_urls_git_gnu
+}
+
+function setup_variables_git_gnu_7() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.18"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="gcc-7-branch"
+
+    setup_base_urls_git_gnu
+}
+
+function setup_variables_git_gnu_6() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.18"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="gcc-6-branch"
+
+    setup_base_urls_git_gnu
+}
+
+function setup_variables_git_gnu_5() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.17.1"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="gcc-5-branch"
+
+    setup_base_urls_git_gnu
+}
+
+function setup_variables_git_linaro_7() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.20"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="linaro-local/gcc-7-integration-branch"
+
+    setup_base_urls_git_linaro
+}
+
+function setup_variables_git_linaro_6() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.20"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="linaro-local/gcc-6-integration-branch"
+
+    setup_base_urls_git_linaro
+}
+
+function setup_variables_git_linaro_5() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.17.1"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="linaro-local/gcc-5-integration-branch"
+
+    setup_base_urls_git_linaro
+}
+
+function setup_variables_git_linaro_4() {
+    BINUTILS="binutils-2_31-branch"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="master"
+    ISL="isl-0.17.1"
+    GLIBC="glibc-2.28"
+    LINUX="v4.18"
+    GCC="linaro-local/releases/linaro-4.9-2017.01"
+
+    setup_base_urls_git_linaro
+}

--- a/git_source_config.sh
+++ b/git_source_config.sh
@@ -1,9 +1,9 @@
 function setup_common_urls_git() {
     MPFR_BASE_URL="https://www.mpfr.org/mpfr-current/"
     GMP_BASE_URL="https://ftp.gnu.org/gnu/gmp/"
+    MPC_BASE_URL="https://ftp.gnu.org/gnu/mpc/"
+    ISL_BASE_URL="http://isl.gforge.inria.fr/"
     BINUTILS_GIT_URL="https://git.linaro.org/toolchain/binutils-gdb.git"
-    ISL_GIT_URL="git://repo.or.cz/isl.git"
-    MPC_GIT_URL="https://scm.gforge.inria.fr/anonscm/git/mpc/mpc.git"
     GLIBC_GIT_URL="git://sourceware.org/git/glibc.git"
     LINUX_GIT_URL="git://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"
 }
@@ -21,11 +21,11 @@ function setup_base_urls_git_linaro() {
 }
 
 function setup_variables_git_gnu_9() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.18"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="master"
@@ -34,11 +34,11 @@ function setup_variables_git_gnu_9() {
 }
 
 function setup_variables_git_gnu_8() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.18"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="gcc-8-branch"
@@ -47,11 +47,11 @@ function setup_variables_git_gnu_8() {
 }
 
 function setup_variables_git_gnu_7() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.18"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="gcc-7-branch"
@@ -60,11 +60,11 @@ function setup_variables_git_gnu_7() {
 }
 
 function setup_variables_git_gnu_6() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.18"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="gcc-6-branch"
@@ -73,11 +73,11 @@ function setup_variables_git_gnu_6() {
 }
 
 function setup_variables_git_gnu_5() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.17.1"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="gcc-5-branch"
@@ -86,11 +86,11 @@ function setup_variables_git_gnu_5() {
 }
 
 function setup_variables_git_linaro_7() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.20"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="linaro-local/gcc-7-integration-branch"
@@ -99,11 +99,11 @@ function setup_variables_git_linaro_7() {
 }
 
 function setup_variables_git_linaro_6() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.20"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="linaro-local/gcc-6-integration-branch"
@@ -112,11 +112,11 @@ function setup_variables_git_linaro_6() {
 }
 
 function setup_variables_git_linaro_5() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.17.1"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="linaro-local/gcc-5-integration-branch"
@@ -125,11 +125,11 @@ function setup_variables_git_linaro_5() {
 }
 
 function setup_variables_git_linaro_4() {
-    BINUTILS="binutils-2_31-branch"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
-    MPC="master"
+    GMP="gmp-6.1.2"
+    MPC="mpc-1.1.0"
     ISL="isl-0.17.1"
+    BINUTILS="binutils-2_31-branch"
     GLIBC="glibc-2.28"
     LINUX="v4.18"
     GCC="linaro-local/releases/linaro-4.9-2017.01"

--- a/tar_source_config.sh
+++ b/tar_source_config.sh
@@ -1,0 +1,126 @@
+function setup_common_urls_tar() {
+    MPFR_BASE_URL="https://www.mpfr.org/mpfr-current/"
+    GMP_BASE_URL="https://ftp.gnu.org/gnu/gmp/"
+    MPC_BASE_URL="https://ftp.gnu.org/gnu/mpc/"
+    GLIBC_BASE_URL="https://ftp.gnu.org/gnu/glibc/"
+    LINUX_BASE_URL="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-"
+    BINUTILS_BASE_URL="https://ftp.gnu.org/gnu/binutils/binutils-"
+    ISL_BASE_URL="http://isl.gforge.inria.fr/"
+}
+
+function setup_base_urls_tar_gnu() {
+    GCC_BASE_URL="https://mirrors.kernel.org/gnu/gcc/"  
+
+    setup_common_urls_tar
+}
+
+function setup_base_urls_tar_linaro() {
+    GCC_BASE_URL="https://git.linaro.org/toolchain/gcc.git/snapshot/gcc-"  
+
+    setup_common_urls_tar
+}
+
+function setup_variables_tar_gnu_8() {
+    BINUTILS="2.31"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="mpc-1.1.0"
+    ISL="isl-0.18"
+    GLIBC="glibc-2.28"
+    LINUX="4.18"
+    GCC="gcc-8.2.0"
+
+    setup_base_urls_tar_gnu
+}
+
+function setup_variables_tar_gnu_7() {
+    BINUTILS="2.31"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="mpc-1.1.0"
+    ISL="isl-0.18"
+    GLIBC="glibc-2.28"
+    LINUX="4.18"
+    GCC="gcc-7.3.0"
+
+    setup_base_urls_tar_gnu
+}
+
+function setup_variables_tar_gnu_6() {
+    BINUTILS="2.31"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="mpc-1.1.0"
+    ISL="isl-0.18"
+    GLIBC="glibc-2.28"
+    LINUX="4.18"
+    GCC="gcc-6.4.0"
+
+    setup_base_urls_tar_gnu
+}
+
+function setup_variables_tar_gnu_5() {
+    BINUTILS="2.31"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="mpc-1.1.0"
+    ISL="isl-0.17.1"
+    GLIBC="glibc-2.28"
+    LINUX="4.18"
+    GCC="gcc-5.5.0"
+
+    setup_base_urls_tar_gnu
+}
+
+function setup_variables_tar_linaro_7() {
+    BINUTILS="2.31"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="mpc-1.1.0"
+    ISL="isl-0.20"
+    GLIBC="glibc-2.28"
+    LINUX="4.18"
+    GCC="linaro-snapshot-7.3-2018.06"
+
+    setup_base_urls_tar_linaro
+}
+
+function setup_variables_tar_linaro_6() {
+    BINUTILS="2.31"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="mpc-1.1.0"
+    ISL="isl-0.20"
+    GLIBC="glibc-2.28"
+    LINUX="4.18"
+    GCC="linaro-snapshot-6.4-2018.06"
+
+    setup_base_urls_tar_linaro
+}
+
+function setup_variables_tar_linaro_5() {
+    BINUTILS="2.31"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="mpc-1.1.0"
+    ISL="isl-0.17.1"
+    GLIBC="glibc-2.28"
+    LINUX="4.18"
+    GCC="linaro-5.5-2017.10"
+
+    setup_base_urls_tar_linaro
+}
+
+function setup_variables_tar_linaro_4() {
+    BINUTILS="2.31"
+    GMP="gmp-6.1.2"
+    MPFR="mpfr-4.0.1"
+    MPC="mpc-1.1.0"
+    ISL="isl-0.17.1"
+    GLIBC="glibc-2.28"
+    LINUX="4.18"
+    GCC="linaro-4.9-2017.01"
+    ISL="isl-0.17.1"
+
+    setup_base_urls_tar_linaro
+}

--- a/tar_source_config.sh
+++ b/tar_source_config.sh
@@ -2,10 +2,10 @@ function setup_common_urls_tar() {
     MPFR_BASE_URL="https://www.mpfr.org/mpfr-current/"
     GMP_BASE_URL="https://ftp.gnu.org/gnu/gmp/"
     MPC_BASE_URL="https://ftp.gnu.org/gnu/mpc/"
+    ISL_BASE_URL="http://isl.gforge.inria.fr/"
+    BINUTILS_BASE_URL="https://ftp.gnu.org/gnu/binutils/binutils-"
     GLIBC_BASE_URL="https://ftp.gnu.org/gnu/glibc/"
     LINUX_BASE_URL="https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-"
-    BINUTILS_BASE_URL="https://ftp.gnu.org/gnu/binutils/binutils-"
-    ISL_BASE_URL="http://isl.gforge.inria.fr/"
 }
 
 function setup_base_urls_tar_gnu() {
@@ -21,11 +21,11 @@ function setup_base_urls_tar_linaro() {
 }
 
 function setup_variables_tar_gnu_8() {
-    BINUTILS="2.31"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
+    GMP="gmp-6.1.2"
     MPC="mpc-1.1.0"
     ISL="isl-0.18"
+    BINUTILS="2.31"
     GLIBC="glibc-2.28"
     LINUX="4.18"
     GCC="gcc-8.2.0"
@@ -34,11 +34,11 @@ function setup_variables_tar_gnu_8() {
 }
 
 function setup_variables_tar_gnu_7() {
-    BINUTILS="2.31"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
+    GMP="gmp-6.1.2"
     MPC="mpc-1.1.0"
     ISL="isl-0.18"
+    BINUTILS="2.31"
     GLIBC="glibc-2.28"
     LINUX="4.18"
     GCC="gcc-7.3.0"
@@ -47,11 +47,11 @@ function setup_variables_tar_gnu_7() {
 }
 
 function setup_variables_tar_gnu_6() {
-    BINUTILS="2.31"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
+    GMP="gmp-6.1.2"
     MPC="mpc-1.1.0"
     ISL="isl-0.18"
+    BINUTILS="2.31"
     GLIBC="glibc-2.28"
     LINUX="4.18"
     GCC="gcc-6.4.0"
@@ -60,11 +60,11 @@ function setup_variables_tar_gnu_6() {
 }
 
 function setup_variables_tar_gnu_5() {
-    BINUTILS="2.31"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
+    GMP="gmp-6.1.2"
     MPC="mpc-1.1.0"
     ISL="isl-0.17.1"
+    BINUTILS="2.31"
     GLIBC="glibc-2.28"
     LINUX="4.18"
     GCC="gcc-5.5.0"
@@ -73,11 +73,11 @@ function setup_variables_tar_gnu_5() {
 }
 
 function setup_variables_tar_linaro_7() {
-    BINUTILS="2.31"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
+    GMP="gmp-6.1.2"
     MPC="mpc-1.1.0"
     ISL="isl-0.20"
+    BINUTILS="2.31"
     GLIBC="glibc-2.28"
     LINUX="4.18"
     GCC="linaro-snapshot-7.3-2018.06"
@@ -86,11 +86,11 @@ function setup_variables_tar_linaro_7() {
 }
 
 function setup_variables_tar_linaro_6() {
-    BINUTILS="2.31"
+    MPFR="mpfr-4.0.1"    
     GMP="gmp-6.1.2"
-    MPFR="mpfr-4.0.1"
     MPC="mpc-1.1.0"
     ISL="isl-0.20"
+    BINUTILS="2.31"
     GLIBC="glibc-2.28"
     LINUX="4.18"
     GCC="linaro-snapshot-6.4-2018.06"
@@ -99,11 +99,11 @@ function setup_variables_tar_linaro_6() {
 }
 
 function setup_variables_tar_linaro_5() {
-    BINUTILS="2.31"
+    MPFR="mpfr-4.0.1"    
     GMP="gmp-6.1.2"
-    MPFR="mpfr-4.0.1"
     MPC="mpc-1.1.0"
     ISL="isl-0.17.1"
+    BINUTILS="2.31"
     GLIBC="glibc-2.28"
     LINUX="4.18"
     GCC="linaro-5.5-2017.10"
@@ -112,15 +112,14 @@ function setup_variables_tar_linaro_5() {
 }
 
 function setup_variables_tar_linaro_4() {
-    BINUTILS="2.31"
-    GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
+    GMP="gmp-6.1.2"
     MPC="mpc-1.1.0"
     ISL="isl-0.17.1"
+    BINUTILS="2.31"
     GLIBC="glibc-2.28"
     LINUX="4.18"
     GCC="linaro-4.9-2017.01"
-    ISL="isl-0.17.1"
 
     setup_base_urls_tar_linaro
 }

--- a/tests/dockerfile_debian9.arm-linux-gnueabi
+++ b/tests/dockerfile_debian9.arm-linux-gnueabi
@@ -1,0 +1,12 @@
+FROM debian:stretch
+
+WORKDIR /home/work_dir
+
+RUN apt-get update -y
+RUN apt-get install -y build-essential make gawk git texinfo
+
+ENV PATH="/home/work_dir/build-tools-gcc:${PATH}"
+
+RUN git clone -b major-refactoring https://github.com/franzflasch/build-tools-gcc.git
+
+RUN "build -a arm -s gnu -v 8 -V -t"


### PR DESCRIPTION
GCC 8 only builds with isl-0.18. With isl-0.20 I get a bunch of isl related errors. Suggested fix on the GCC mailing lists is to use version 0.18