### PR TITLE
Releases bump

### DIFF
--- a/build
+++ b/build
@@ -249,7 +249,7 @@ function parse_parameters() {
             "gnu:4") die "Will not build, Use Linaro instead" ;;
             "gnu:5") GCC=gcc-5.5.0
                      ISL="isl-0.17.1" ;;
-            "gnu:6") GCC=gcc-6.4.0 ;;
+            "gnu:6") GCC=gcc-6.5.0 ;;
             "gnu:7") GCC=gcc-7.3.0 ;;
             "gnu:8") GCC=gcc-8.2.0 ;;
             "gnu:9") die "GCC 9.0 is currently a WIP so there is no tarball to download! Either use the git repo or choose a new version..." ;;

--- a/build
+++ b/build
@@ -172,14 +172,14 @@ function setup_variables() {
     JOBS="-j$(($(nproc --all) + 1))"
 
     # Binary versions
-    BINUTILS_git="binutils-2_31-branch"
-    BINUTILS_tar="2.31"
+    BINUTILS_git="binutils-2_31_1-branch"
+    BINUTILS_tar="2.31.1"
     GMP="gmp-6.1.2"
     MPFR="mpfr-4.0.1"
     MPC="mpc-1.1.0"
     ISL="isl-0.20"
     GLIBC="glibc-2.28"
-    LINUX="4.18"
+    LINUX="4.19"
 
     # Start of script
     START=$(date +%s)

--- a/build
+++ b/build
@@ -257,7 +257,7 @@ function parse_parameters() {
                         ISL="isl-0.17.1" ;;
             "linaro:5") GCC=linaro-5.5-2017.10
                         ISL="isl-0.17.1" ;;
-            "linaro:6") GCC=linaro-snapshot-6.4-2018.11 ;;
+            "linaro:6") GCC=linaro-snapshot-6.5-2018.11 ;;
             "linaro:7") GCC=linaro-snapshot-7.3-2018.06 ;;
             "linaro:8") die "There's no such thing as Linaro 8.x Clannad..." -h ;;
             "linaro:9") die "There's no such thing as Linaro 9.x Clannad..." -h ;;


### PR DESCRIPTION
* GCC 6.5.0
* Binutils 2.31.1
* Linux 4.19
* Properly bump Linaro 6 release (fixes #18)