### PR TITLE
build: Fix build axel

### DIFF
--- a/build
+++ b/build
@@ -343,7 +343,7 @@ function build_binaries() {
         git -C "${AXEL}" pull
         (
             cd "${AXEL}" || die "Issue with cloning axel source!"
-            ./autogen.sh
+            autoreconf -fiv
             ./configure --prefix="$(dirname "${PREBUILTS_BIN}")"
             make "${JOBS}" || die "Error building axel!"
             make "${JOBS}" install || die "Error installing axel!"


### PR DESCRIPTION
- Latest axel source has been removed autogen.sh, change to "autoreconf -fiv" to generate configure.
- Change it to make axel still avaliable for build.

Signed-off-by: Keternal <Z5X67280@163.com>